### PR TITLE
User can't register with the same email address by changing uppercase/lowercase letter of email

### DIFF
--- a/controllers/registration_test.go
+++ b/controllers/registration_test.go
@@ -89,6 +89,66 @@ var _ = Describe("RegistrationController", func() {
 
 					Expect(path).To(Equal("/register"))
 				})
+
+				Context("given the email already exist in the database", func() {
+					Context("given the email in lowercase letter", func() {
+						It("sets flash error message", func() {
+							FabricateUser("John", "john@example.com", "secret")
+							form := url.Values{
+								"name":     {"John"},
+								"email":    {"john@example.com"},
+								"password": {"secret"},
+							}
+							body := strings.NewReader(form.Encode())
+							response := MakeRequest("POST", "/register", body)
+							flash := GetFlash(response.Cookies())
+
+							Expect(flash.Data["error"]).To(Equal("Email already exists"))
+						})
+
+						It("re-renders the registration page", func() {
+							form := url.Values{
+								"name":     {""},
+								"email":    {"john@example.com"},
+								"password": {"secret"},
+							}
+							body := strings.NewReader(form.Encode())
+							response := MakeRequest("POST", "/register", body)
+							path := GetUrlPath(response)
+
+							Expect(path).To(Equal("/register"))
+						})
+					})
+
+					Context("given the email in lowercase and uppercase letter", func() {
+						It("sets flash error message", func() {
+							FabricateUser("John", "john@example.com", "secret")
+							form := url.Values{
+								"name":     {"John"},
+								"email":    {"JoHn@example.com"},
+								"password": {"secret"},
+							}
+							body := strings.NewReader(form.Encode())
+							response := MakeRequest("POST", "/register", body)
+							flash := GetFlash(response.Cookies())
+
+							Expect(flash.Data["error"]).To(Equal("Email already exists"))
+						})
+
+						It("re-renders the registration page", func() {
+							form := url.Values{
+								"name":     {""},
+								"email":    {"JoHn@example.com"},
+								"password": {"secret"},
+							}
+							body := strings.NewReader(form.Encode())
+							response := MakeRequest("POST", "/register", body)
+							path := GetUrlPath(response)
+
+							Expect(path).To(Equal("/register"))
+						})
+					})
+				})
 			})
 		})
 

--- a/models/user.go
+++ b/models/user.go
@@ -19,7 +19,10 @@ func CreateUser(u *User) (id int64, err error) {
 
 func (u *User) IsExistingUser() bool {
 	o := orm.NewOrm()
-	err := o.Read(u, "Email")
+	var user User
+
+	err := o.QueryTable(User{}).Filter("email__iexact", u.Email).One(&user)
+
 	return err == nil
 }
 

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -105,14 +105,27 @@ var _ = Describe("User", func() {
 
 	Describe("#IsExistingUser", func() {
 		Context("given the user already exist", func() {
-			It("returns true", func() {
-				email := "john@example.com"
-				FabricateUser("John", email, "secret")
-				user := &models.User{
-					Email: email,
-				}
+			Context("given the email in lowercase letter", func() {
+				It("returns true", func() {
+					email := "john@example.com"
+					FabricateUser("John", email, "secret")
+					user := &models.User{
+						Email: email,
+					}
 
-				Expect(user.IsExistingUser()).To(BeTrue())
+					Expect(user.IsExistingUser()).To(BeTrue())
+				})
+			})
+
+			Context("given the email in lowercase and uppercase letter", func() {
+				It("returns true", func() {
+					FabricateUser("John", "john@example.com", "secret")
+					user := &models.User{
+						Email: "JoHn@example.com",
+					}
+
+					Expect(user.IsExistingUser()).To(BeTrue())
+				})
 			})
 		})
 


### PR DESCRIPTION
https://github.com/junan/google-scraper/projects/1#card-56478576

## What happened 👀

User can't register with the same email address by changing uppercase/lowercase letter of email

## Insight 📝

Used Beego's [iexact](https://beego.me/docs/mvc/model/query.md#iexact) operator

## Proof Of Work 📹

Spec should be passed
